### PR TITLE
fixed Menu

### DIFF
--- a/NoSleep/NoSleep.csproj
+++ b/NoSleep/NoSleep.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <OutputType>WinExe</OutputType>
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
     <Product>NoSleep</Product>
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>

--- a/NoSleep/TrayMenuBuilder.cs
+++ b/NoSleep/TrayMenuBuilder.cs
@@ -15,8 +15,7 @@ namespace NoSleep
         private readonly ToolStripMenuItem itemStartWithWindows;
         private readonly ToolStripMenuItem itemCheckForUpdates;
 
-        private readonly ContextMenuStrip runningContextMenu;
-        private readonly ContextMenuStrip stoppedContextMenu;
+        private readonly ContextMenuStrip contextMenu;
 
         public event EventHandler AboutClicked;
         public event EventHandler StartClicked;
@@ -48,20 +47,33 @@ namespace NoSleep
             itemStartWithWindows.Click += (s, e) => StartWithWindowsClicked?.Invoke(s, e);
             itemStartWithWindows.Checked = RegistryHelper.DoesStartUpKeyExist;
 
-            // Build the context menus
-            runningContextMenu = BuildRunningMenu();
-            stoppedContextMenu = BuildStoppedMenu();
+            // Create the single context menu
+            contextMenu = new ContextMenuStrip();
         }
 
         /// <summary>
         /// Gets the context menu for when sleep prevention is running.
         /// </summary>
-        public ContextMenuStrip RunningContextMenu => runningContextMenu;
+        public ContextMenuStrip RunningContextMenu
+        {
+            get
+            {
+                RebuildMenu(true);
+                return contextMenu;
+            }
+        }
 
         /// <summary>
         /// Gets the context menu for when sleep prevention is stopped.
         /// </summary>
-        public ContextMenuStrip StoppedContextMenu => stoppedContextMenu;
+        public ContextMenuStrip StoppedContextMenu
+        {
+            get
+            {
+                RebuildMenu(false);
+                return contextMenu;
+            }
+        }
 
         /// <summary>
         /// Updates the "Startup With Windows" menu item checked state.
@@ -71,36 +83,22 @@ namespace NoSleep
             itemStartWithWindows.Checked = RegistryHelper.DoesStartUpKeyExist;
         }
 
-        private ContextMenuStrip BuildRunningMenu()
+        private void RebuildMenu(bool isRunning)
         {
-            ContextMenuStrip menu = new ContextMenuStrip();
-            // Primary action first
-            menu.Items.Add(itemStop);
-            menu.Items.Add(new ToolStripSeparator());
-            // Settings and info
-            menu.Items.Add(itemStartWithWindows);
-            menu.Items.Add(itemCheckForUpdates);
-            menu.Items.Add(itemAbout);
-            menu.Items.Add(new ToolStripSeparator());
-            // Exit
-            menu.Items.Add(itemClose);
-            return menu;
-        }
+            contextMenu.Items.Clear();
 
-        private ContextMenuStrip BuildStoppedMenu()
-        {
-            ContextMenuStrip menu = new ContextMenuStrip();
             // Primary action first
-            menu.Items.Add(itemStart);
-            menu.Items.Add(new ToolStripSeparator());
+            contextMenu.Items.Add(isRunning ? itemStop : itemStart);
+            contextMenu.Items.Add(new ToolStripSeparator());
+
             // Settings and info
-            menu.Items.Add(itemStartWithWindows);
-            menu.Items.Add(itemCheckForUpdates);
-            menu.Items.Add(itemAbout);
-            menu.Items.Add(new ToolStripSeparator());
+            contextMenu.Items.Add(itemStartWithWindows);
+            contextMenu.Items.Add(itemCheckForUpdates);
+            contextMenu.Items.Add(itemAbout);
+            contextMenu.Items.Add(new ToolStripSeparator());
+
             // Exit
-            menu.Items.Add(itemClose);
-            return menu;
+            contextMenu.Items.Add(itemClose);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,15 +13,18 @@ A lightweight system tray application that prevents your Windows machine from sl
 - **Visual Status**: Different tray icons indicate whether sleep prevention is active or inactive
 - **Clean Exit**: Properly handles Windows shutdown events
 
-## What's New in v2.1.1
+## What's New in v2.1.2
 
+- 🐛 **Menu Bug Fix** - Fixed missing menu items when switching between running/stopped states
+
+## Previous Releases
+
+### v2.1.1
 - 🔐 **Smart elevation handling** - "Startup With Windows" now works seamlessly for all users with automatic UAC prompting and restart
 - ⏱️ **Uptime display** - Tray icon tooltip shows how long sleep prevention has been running (e.g., "Running 2h 15m")
 - 📋 **Enhanced About dialog** - Now displays version number, admin status, and hotkey configuration
 - ⌨️ **Better hotkey conflict detection** - Clear error messages with option to disable when conflicts occur
 - 🎨 **Cleaner menu** - Removed redundant "Restart as Administrator" option
-
-## Previous Releases
 
 ### v2.0.0
 - ⬆️ Migrated to .NET 8 for better performance and modern C# features


### PR DESCRIPTION
# NoSleep v2.1.2 Release Notes

## 🐛 Bug Fix Release

This is a quick bug fix release addressing a menu display issue introduced in v2.1.1.

### Fixed

- **Context Menu Bug**: Fixed issue where menu items were missing when switching between running and stopped states
  - The running and stopped menus now correctly display all options (Startup With Windows, Check for Updates, About, Close)
  - Only the first item changes between "Stop" and "Start" as intended
  - **Technical**: Refactored from dual menu approach to single dynamically-rebuilt menu to prevent Windows Forms parent conflicts

### What's Included from v2.1.1

All features from v2.1.1 are included:
- 🔐 Smart elevation handling for "Startup With Windows"
- ⏱️ Uptime display in tray icon tooltip
- 📋 Enhanced About dialog with version and admin status
- ⌨️ Better hotkey conflict detection

---

**Full Changelog**: v2.1.1...v2.1.2

**Upgrade Note**: If you're on v2.1.1, this update is recommended to fix the menu display issue.